### PR TITLE
Improved edgelabels for multigraphs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ LightGraphs
 PlotUtils
 NaNMath
 GeometryTypes
+Interpolations

--- a/src/GraphRecipes.jl
+++ b/src/GraphRecipes.jl
@@ -12,7 +12,7 @@ using SparseArrays
 using Statistics
 using NaNMath
 using GeometryTypes
-
+using Interpolations
 
 include("utils.jl")
 include("graph_layouts.jl")


### PR DESCRIPTION
Here I refactor how edgelabels are handled as well as how the curvature is handled. Previously, we used bezier curves to make curves, now we use cubic splines. The problem with bezier curves is that you tend to have less control over exactly where your curves go.

An example:
```julia
using Plots, Random, GraphRecipes
pyplot()
Random.seed!(2)
adjlist = [[1,1,1,1,2], [1,1,2,3,4], [2,2,6,6], [1,2], [1,1,2], [2,3], [6,6,7,7,4], [8,8,8,2,5], [5,5]]
edgelabel = Dict()
d = Dict()
for source in 1:length(adjlist)
    for destiny in adjlist[source]
        if haskey(d, (source, destiny))
            d[(source, destiny)] += 1
        else
            d[(source, destiny)] = 1
        end
        edgelabel[(source, destiny, d[(source, destiny)])] = string(source, "_", destiny, "_",
                                                                  d[(source, destiny)])
    end
end
graphplot(adjlist, nodeshape=:circle, nodesize=0.15, axis_buffer=0.8,
          names="Label ".*string.(1:9), edgelabel_offset=0.0, self_edge_size=0.1,
          edgelabel=edgelabel, curvature_scalar=0.035, arrow=arrow(0.4,0.4), size=(1400,1400))
```
![mult_labels](https://user-images.githubusercontent.com/8610352/61523753-1610d280-aa69-11e9-8fc0-028af6cd140d.png)

**EDIT**

I forgot to mention that this PR adds [Interpolations](https://github.com/JuliaMath/Interpolations.jl) to the dependencies. The library is quite high quality and it is fairly light weight. That said, I would consider creating a custom spline method for GraphRecipes. Maybe one that is both precise and aesthetic, at the moment though, Interpolations is doing a good job and I really don't think that it is adding too much weight to GraphRecipes.
