### PR TITLE
Update axis buffer and allow different curvature scalars for each edge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,1 @@
+* `axis_buffer` can now be a tuple, allowing separate axis buffers for each dimension. Additionally, if one of the dimensions has zero variance, then the axis buffer will still be able to increase the size of that dimension. `curvature_scalar` can now be a matrix, so that each edge can have its own curvature. ([#96])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -287,6 +287,7 @@ ignorenan_extrema(x::AbstractArray{F}) where {F<:AbstractFloat} = NaNMath.extrem
 function extrema_plus_buffer(v, buffmult = 0.2)
     vmin,vmax = extrema(v)
     vdiff = vmax-vmin
-    buffer = vdiff * buffmult
+    zero_buffer = vdiff == 0 ? 1.0 : 0.0
+    buffer = (vdiff+zero_buffer) * buffmult
     vmin - buffer, vmax + buffer
 end


### PR DESCRIPTION
When you create a custom graph layout, you sometimes want the nodes to fall all have the same x/y coordinate. The old code for the axis buffer didn't behave nicely in this case. Additionally, the old code forced you to have the same axis buffer for each dimension. This is fine for most graph layouts that we generate, but it can be problematic with custom layouts (e.g. flowcharts).

I also added the possibility to have different curvature scalars for each edge, which I think is really useful for flowcharts, but also seems handy in general.

## Example
```julia
using Plots, GraphRecipes
using LightGraphs

default(size=(400,400))
g = DiGraph(5)
add_edge!(g, 1, 2)
add_edge!(g, 2, 3)
add_edge!(g, 3, 4)
add_edge!(g, 4, 5)
add_edge!(g, 5, 3)
names = [:Thing, :Thingy, :Thinger, :Things, :Stuff]
x = [0,0,0,0,0]
y = [5,4,3,2,1]
curvature_scalar = zeros(length(names),length(names))
curvature_scalar[5,3] = 1.0
graphplot(g, x=x, y=y, names=names, curvature_scalar=curvature_scalar,
          axis_buffer=(1.1,0.2), w=2, color=:black, nodesize=0.3, nodeshape=:circle)
```
![flow_chart](https://user-images.githubusercontent.com/8610352/74598344-c1076e80-50d4-11ea-8368-f315052a8e7d.png)
cc: @caseykneale 